### PR TITLE
Trello Ticket #14: Remove conference pills and matchup carousel component

### DIFF
--- a/src/assemblies/data/ncaab/matchup/Matchups/Matchups.tsx
+++ b/src/assemblies/data/ncaab/matchup/Matchups/Matchups.tsx
@@ -2,7 +2,6 @@ import React, {FC, ReactElement} from 'react';
 import { ontology } from '../../../../../util';
 import { useSupportedMedia } from '../../../../../util/media/useSupportedMedia';
 import { NcaabMensAllUpcomingGames } from '../../overview/NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames';
-import { WeekMatchupCarousel } from '../WeekMatchupCarousel';
 
 export const MATCHUPS_CLASSNAMES : string[] = [
     "grid",
@@ -29,7 +28,6 @@ export type MatchupsProps = {
 export const Matchups : FC<MatchupsProps>  = (props) =>{
 
     const medium = useSupportedMedia();
-    const groupBy = medium === "mobile" ? 1 : 4;
 
     return (
         <div
@@ -40,13 +38,6 @@ export const Matchups : FC<MatchupsProps>  = (props) =>{
                 onMatchupClick={props.onMatchupClick}
                 onTeamClick={props.onTeamClick}
                 allUpcomingGames={props.gamesThisWeek}/>
-            </div>
-            <div>
-                <WeekMatchupCarousel
-                groupBy={groupBy}
-                onMatchupClick={props.onMatchupClick}
-                onTeamClick={props.onTeamClick}
-                gamesThisWeek={props.allUpcomingGames}/>
             </div>
         </div>
     )

--- a/src/assemblies/data/ncaab/overview/NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames.tsx
+++ b/src/assemblies/data/ncaab/overview/NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames.tsx
@@ -1,11 +1,6 @@
 import React, {FC, ReactElement, useState} from 'react';
-import { Wrapper } from '../../../../../components';
 import { ontology, viusage } from '../../../../../util';
-import { Pill } from '../../../../../components';
-import { Stacked } from '../../../../../components/output/containers/comparison';
-import { TeamMatchupRowProjection } from '../../matchup/TeamMatchupRowProjection';
 import { UpcomingGames } from '../../matchup';
-import { FilterSet } from '../../../../../components/output/containers/filter';
 
 export const NCAAB_MENS_ALL_UPCOMING_GAMES_CONTAINER_CLASSNAMES : string[] = [ 
     "p-4"
@@ -44,33 +39,6 @@ export const isOnTheBubble = (team : ontology.Teamlike)=>{
 
 }
 
-export const ALL_UPCOMING_GAMES_PRESETS : {
-    [key : string] : (table : ontology.ProjectedGamelike[])=>Promise<ontology.ProjectedGamelike[]>
-} = {
-    "All" : async (table)=>table,
-    "Big 12" : async (table)=>{
-        return table.filter((game)=>{
-            return game.home.Conference === "Big 12" || game.away.Conference === "Big 12"
-        })
-    },
-    "PAC 12" : async (table)=>{
-        return table.filter((game)=>{
-            return game.home.Conference === "Pac-12" || game.away.Conference === "Pac-12"
-        })
-    },
-    "ACC" : async (table)=>{
-        return table.filter((game)=>{
-            return game.home.Conference === "Atlantic Coast" || game.away.Conference === "Atlantic Coast"
-        })
-    },
-    "On the Bubble" : async (table)=>{
-        return table.filter((game)=>{
-
-            return isOnTheBubble(game.home) || isOnTheBubble(game.away);
-        })
-    },
-}
-
 export const NcaabMensAllUpcomingGames : FC<NcaabMensAllUpcomingGamesProps>  = (props) =>{
 
     return (
@@ -79,7 +47,6 @@ export const NcaabMensAllUpcomingGames : FC<NcaabMensAllUpcomingGamesProps>  = (
         onMatchupClick={props.onMatchupClick}
         onTeamClick={props.onTeamClick}
         Title={<h2 className='text-2xl'>Today's Games</h2>}
-        presets={ALL_UPCOMING_GAMES_PRESETS}
         games={props.allUpcomingGames}/>
     )
 };

--- a/src/assemblies/data/ncaab/overview/NcaabMensUpcomingGames/NcaabMensUpcomingGames.tsx
+++ b/src/assemblies/data/ncaab/overview/NcaabMensUpcomingGames/NcaabMensUpcomingGames.tsx
@@ -1,11 +1,6 @@
 import React, {FC, ReactElement} from 'react';
-import { Wrapper } from '../../../../../components';
 import { ontology, viusage } from '../../../../../util';
-import { Pill } from '../../../../../components';
-import { Stacked } from '../../../../../components/output/containers/comparison';
-import { TeamMatchupRowProjection } from '../../matchup/TeamMatchupRowProjection';
 import { UpcomingGames } from '../../matchup';
-import { ALL_UPCOMING_GAMES_PRESETS } from '../NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames';
 
 export const NCAAB_MENS_UPCOMING_GAMES_CONTAINER_CLASSNAMES : string[] = [ 
     "p-4"
@@ -39,7 +34,6 @@ export const NcaabMensUpcomingGames : FC<NcaabMensUpcomingGamesProps>  = (props)
         onMatchupClick={props.onMatchupClick}
         onTeamClick={props.onTeamClick}
         Title={<h2 className='text-xl'>Top 25 Games</h2>}
-        presets={ALL_UPCOMING_GAMES_PRESETS}
         games={props.top25Games}/>
     )
 };

--- a/src/assemblies/data/ncaab/team/GameLog/GameLog.tsx
+++ b/src/assemblies/data/ncaab/team/GameLog/GameLog.tsx
@@ -5,7 +5,6 @@ import { Pill } from '../../../../../components';
 import { Stacked } from '../../../../../components/output/containers/comparison';
 import { TeamMatchupRowProjection } from '../../matchup/TeamMatchupRowProjection';
 import { UpcomingGames } from '../../matchup';
-import { ALL_UPCOMING_GAMES_PRESETS } from '../../overview/NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames';
 
 export const GAME_LOG_CONTAINER_CLASSNAMES : string[] = [ 
     "p-4"
@@ -41,7 +40,6 @@ export const GameLog : FC<GameLogProps>  = (props) =>{
         onMatchupClick={props.onMatchupClick}
         onTeamClick={props.onTeamClick}
         Title={<h2 className='text-xl'>Games</h2>}
-        presets={ALL_UPCOMING_GAMES_PRESETS}
         games={props.games}/>
     )
 };


### PR DESCRIPTION
## About
As part of our efforts to add a date picker to the Matchups page, we want to remove this component altogether.

## Description of Changes
* remove `WeekMatchupCarousel` component from `Matchups.tsx`
* remove `ALL_UPCOMING_GAMES_PRESETS` from all applicable locations

## Trello Ticket
https://trello.com/c/l32JEX1Y/14-remove-this-weeks-matchups-carousel

## Screenshots
![Screenshot 2024-02-06 at 7 23 03 PM](https://github.com/gameday-guru/gdg-component-library/assets/46224768/26cf0332-3ea8-413b-8aed-c6bb0f1a2f00)

