### PR TITLE
GDG-3: Matchup Calendar Feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdg-component-library",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gdg-component-library",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.21.0",
@@ -27,7 +27,7 @@
         "decimal.js": "^10.4.2",
         "dotenv": "^16.0.3",
         "fast-levenshtein": "^3.0.0",
-        "firebase": "^9.23.0",
+        "firebase": "^9.14.0",
         "framer-motion": "^6.5.0",
         "fs-extra": "^10.0.0",
         "gdgwep": "^0.0.3",
@@ -38,9 +38,11 @@
         "react-bootstrap-icons": "^1.8.4",
         "react-chartjs-2": "^4.3.1",
         "react-checkmark": "^1.4.0",
+        "react-datepicker": "^6.2.0",
         "react-dev-utils": "^12.0.1",
         "react-dom": "^18.1.0",
         "react-firebase-hooks": "^5.1.1",
+        "react-icons": "^5.0.1",
         "react-loading-skeleton": "^3.1.0",
         "react-markdown": "7",
         "react-refresh": "^0.11.0",
@@ -79,6 +81,7 @@
         "@types/jest": "^27.0.1",
         "@types/node": "^16.7.13",
         "@types/react": "^18.0.0",
+        "@types/react-datepicker": "^6.0.3",
         "@types/react-dom": "^18.0.0",
         "@types/styled-components": "^5.1.25",
         "@vitejs/plugin-react": "^2.1.0",
@@ -2982,6 +2985,54 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.1.tgz",
       "integrity": "sha512-Dq5rYfEpdeel0bLVN+nfD1VWmzCkK+pJbSjIawGE+RY4+NIJqhbUDDQjvV0NUK84fMfwxvtFoCtEe70HfZjFcw=="
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.9.tgz",
+      "integrity": "sha512-p86wynZJVEkEq2BBjY/8p2g3biQ6TlgT4o/3KgFKyTWoJLU1GZ8wpctwRqtkEl2tseYA+kw7dBAIDFcednfI5w==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.8",
+        "@floating-ui/utils": "^0.2.1",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
@@ -5506,6 +5557,17 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-datepicker": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-6.0.3.tgz",
+      "integrity": "sha512-3x5flRBrEgC3fFrBryFIrxbLf8bOkte/GNryPjfnXu3my4/XZeaML/01U+XArMCLfk2d3pei6ccNIgTlpe4c5g==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/react": "^0.26.2",
+        "@types/react": "*",
+        "date-fns": "^3.3.1"
+      }
+    },
     "node_modules/@types/react-dom": {
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
@@ -7774,6 +7836,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -14128,6 +14199,22 @@
         "react": "^16.8.6"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-6.2.0.tgz",
+      "integrity": "sha512-GzEOiE6yLfp9P6XNkOhXuYtZHzoAx3tirbi7/dj2WHlGM+NGE1lefceqGR0ZrYsYaqsNJhIJFTgwUpzVzA+mjw==",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.2",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.3.1",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.13.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18",
+        "react-dom": "^16.9.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -14246,6 +14333,14 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -14302,6 +14397,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/react-onclickoutside": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
+      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/react-onclickoutside/blob/master/FUNDING.md"
+      },
+      "peerDependencies": {
+        "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
+        "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -15910,6 +16018,11 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tailwindcss": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gdg-component-library",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "files": [
     "dist",
     "assets",
@@ -45,9 +45,11 @@
     "react-bootstrap-icons": "^1.8.4",
     "react-chartjs-2": "^4.3.1",
     "react-checkmark": "^1.4.0",
+    "react-datepicker": "^6.2.0",
     "react-dev-utils": "^12.0.1",
     "react-dom": "^18.1.0",
     "react-firebase-hooks": "^5.1.1",
+    "react-icons": "^5.0.1",
     "react-loading-skeleton": "^3.1.0",
     "react-markdown": "7",
     "react-refresh": "^0.11.0",
@@ -96,6 +98,7 @@
     "@types/jest": "^27.0.1",
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
+    "@types/react-datepicker": "^6.0.3",
     "@types/react-dom": "^18.0.0",
     "@types/styled-components": "^5.1.25",
     "@vitejs/plugin-react": "^2.1.0",

--- a/src/assemblies/data/ncaab/generic/FormatDate/formatDate.ts
+++ b/src/assemblies/data/ncaab/generic/FormatDate/formatDate.ts
@@ -1,0 +1,17 @@
+export function formatDate(inputDate: string) {
+    const months = [
+      'January', 'February', 'March', 'April',
+      'May', 'June', 'July', 'August',
+      'September', 'October', 'November', 'December'
+    ];
+  
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  
+    const dateObject = new Date(inputDate);
+    const dayOfWeek = days[dateObject.getUTCDay()];
+    const month = months[dateObject.getUTCMonth()];
+    const dayDate = dateObject.getUTCDate();
+    const year = dateObject.getUTCFullYear();
+  
+    return `${dayOfWeek}, ${month} ${dayDate}, ${year}`;
+  }

--- a/src/assemblies/data/ncaab/matchup/MatchupCalendar/MatchupCalendar.tsx
+++ b/src/assemblies/data/ncaab/matchup/MatchupCalendar/MatchupCalendar.tsx
@@ -1,0 +1,38 @@
+import React, { FC, useState } from 'react';
+import DatePicker from 'react-datepicker';
+import { Calendar } from 'react-bootstrap-icons';
+import 'react-datepicker/dist/react-datepicker.css';
+
+export type MatchupCalendarProps = {
+  onDateSelect: (date: string) => void;
+};
+
+const MatchupCalendar: FC<MatchupCalendarProps> = ({ onDateSelect }) => {
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  const handleDateChange = (date: Date | null) => {
+    setSelectedDate(date);
+    onDateSelect(date ? date.toLocaleDateString('en-US') : ''); // Format the date to include only the year
+  };
+
+  return (
+    <div className="d-flex align-items-center">
+      <DatePicker
+        selected={selectedDate}
+        onChange={handleDateChange}
+        dateFormat="MMMM d, yyyy"
+        customInput={
+          <button
+            className="btn btn-outline-secondary"
+            type="button"
+            style={{ backgroundColor: 'transparent' }} // Set the initial background color
+          >
+            <Calendar style={{ marginRight: '5px' }} />
+          </button>
+        }
+      />
+    </div>
+  );
+};
+
+export default MatchupCalendar;

--- a/src/assemblies/data/ncaab/matchup/MatchupCalendar/index.ts
+++ b/src/assemblies/data/ncaab/matchup/MatchupCalendar/index.ts
@@ -1,0 +1,1 @@
+export * from "./MatchupCalendar";

--- a/src/assemblies/data/ncaab/matchup/UpcomingGames/UpcomingGamesDesktop.tsx
+++ b/src/assemblies/data/ncaab/matchup/UpcomingGames/UpcomingGamesDesktop.tsx
@@ -1,95 +1,146 @@
-import React, {FC, ReactElement, useState} from 'react';
-import { Wrapper } from '../../../../../components';
-import { Pill } from '../../../../../components';
-import { ontology } from '../../../../../util';
-import { MockProjectedGame } from '../../../../../util/ontology';
-import { TeamMatchupRowProjection } from '../TeamMatchupRowProjection';
-import { FilterSet } from '../../../../../components/output/containers/filter';
-import { Viusagelike } from '../../../../../util/viusage/primary';
+import React, { FC, useState } from "react";
+import { Wrapper } from "../../../../../components";
+import { Pill } from "../../../../../components";
+import { ontology } from "../../../../../util";
+import { MockProjectedGame } from "../../../../../util/ontology";
+import { TeamMatchupRowProjection } from "../TeamMatchupRowProjection";
+import { FilterSet } from "../../../../../components/output/containers/filter";
+import { Viusagelike } from "../../../../../util/viusage/primary";
+import { useOnceProcessor } from "../../../../../logic/processing/react/reactProcessor";
+import MatchupCalendar from "../MatchupCalendar/MatchupCalendar";
+import { formatDate } from "../../generic/FormatDate/formatDate";
 
-export const UPCOMING_GAMES_DESKTOP_CONTAINER_CLASSNAMES : string[] = [
-    "rounded-lg",
-    "p-4"
+export const UPCOMING_GAMES_DESKTOP_CONTAINER_CLASSNAMES: string[] = [
+  "rounded-lg",
+  "p-4",
 ];
-export const UPCOMING_GAMES_DESKTOP_CONTAINER_STYLE : React.CSSProperties = {
-};
+export const UPCOMING_GAMES_DESKTOP_CONTAINER_STYLE: React.CSSProperties = {};
 
-export const UPCOMING_GAMES_DESKTOP_INNER_CLASSNAMES : string[] = [ ];
-export const UPCOMING_GAMES_DESKTOP_INNER_STYLE : React.CSSProperties = {
-    textAlign : "left"
+export const UPCOMING_GAMES_DESKTOP_INNER_CLASSNAMES: string[] = [];
+export const UPCOMING_GAMES_DESKTOP_INNER_STYLE: React.CSSProperties = {
+  textAlign: "left",
 };
 
 export type UpcomingGamesDesktopProps = {
-     children ? : React.ReactNode;
-    style ? : React.CSSProperties;
-    overrideStyle ? : boolean;
-    classNames ? : string[];
-    overrideClasses ? : boolean;
-    responsive ? : boolean;
-    which ? : string;
-    games ? : ontology.ProjectedGamelike[];
-    onTeamClick ? : (teamId : string)=>Promise<void>;
-    onMatchupClick ? : (gameId : string)=>Promise<void>;
-    options ? : string[];
-    viusage ? : Viusagelike;
-    Title ? : React.ReactNode;
-    presets ? : {
-        [key : string] : (table : ontology.ProjectedGamelike[])=>Promise<ontology.ProjectedGamelike[]>
-    }
-    stackedGamblers ? : boolean;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+  overrideStyle?: boolean;
+  classNames?: string[];
+  overrideClasses?: boolean;
+  responsive?: boolean;
+  which?: string;
+  games?: ontology.ProjectedGamelike[];
+  onTeamClick?: (teamId: string) => Promise<void>;
+  onMatchupClick?: (gameId: string) => Promise<void>;
+  options?: string[];
+  viusage?: Viusagelike;
+  Title?: React.ReactNode;
+  presets?: {
+    [key: string]: (
+      table: ontology.ProjectedGamelike[]
+    ) => Promise<ontology.ProjectedGamelike[]>;
+  };
+  stackedGamblers?: boolean;
 };
 
-export const UpcomingGamesDesktop : FC<UpcomingGamesDesktopProps>  = (props) =>{
+export const UpcomingGamesDesktop: FC<UpcomingGamesDesktopProps> = (props) => {
+  let userSelectedGames = null;
+  const { getProjectedGamesTable } = useOnceProcessor();
+  const [selectedDate, setSelectedDate] = useState<string>("");
 
-    const [renderCount, setRenderCount] = useState(100);
+  const handleDateSelect = (date: string) => {
+    setSelectedDate(date);
 
-    const _gameProjections = (props.games||Array(10).fill(MockProjectedGame));
+    // Get the projected games for the selected date
+    userSelectedGames = getProjectedGamesTable(new Date(date));
 
-    const [upcomingGames, setUpcomingGamesDesktop] = useState(_gameProjections);
-
-    const gameProjections = upcomingGames
-    .slice(0, renderCount)
-    .map((entry, i)=>{
+    const sortedGames =
+      userSelectedGames &&
+      Object.values(userSelectedGames).sort((gameA, gameB) => {
         return (
-            <TeamMatchupRowProjection 
-                stackedGamblers={props.stackedGamblers}
-                onMatchupClick={props.onMatchupClick}
-                onTeamClick={props.onTeamClick}
-                key={entry.game.GameID + `x${i}`}
-                home={entry.home}
-                away={entry.away}
-                game={entry.game}
-                gameProjection={entry.gameProjection}/>
-        )
+          new Date(gameA.game.DateTimeUTC || gameA.game.Day).getTime() -
+          new Date(gameB.game.DateTimeUTC || gameB.game.Day).getTime()
+        );
+      });
+    // Update the upcoming games
+    setUpcomingGamesDesktop(sortedGames || []);
+  };
+
+  const [renderCount, setRenderCount] = useState(100);
+
+  const _gameProjections =
+    userSelectedGames || props.games || Array(10).fill(MockProjectedGame);
+
+  const [upcomingGames, setUpcomingGamesDesktop] = useState(_gameProjections);
+
+  const gameProjections = upcomingGames
+    .slice(0, renderCount)
+    .map((entry, i) => {
+      return (
+        <TeamMatchupRowProjection
+          stackedGamblers={props.stackedGamblers}
+          onMatchupClick={props.onMatchupClick}
+          onTeamClick={props.onTeamClick}
+          key={entry.game.GameID + `x${i}`}
+          home={entry.home}
+          away={entry.away}
+          game={entry.game}
+          gameProjection={entry.gameProjection}
+        />
+      );
     });
 
-    return (
-     
-        <Wrapper
-        viusage={props.viusage||"wrap"}
-        classNames={[...!props.overrideClasses ? UPCOMING_GAMES_DESKTOP_CONTAINER_CLASSNAMES : [], ...props.classNames||[]]}
-        style={{...!props.overrideStyle ? UPCOMING_GAMES_DESKTOP_CONTAINER_STYLE : {}, ...props.style}}>
-        <div
-        className={[...!props.overrideClasses ? UPCOMING_GAMES_DESKTOP_INNER_CLASSNAMES : [], ...props.classNames||[]].join(" ")}
-        style={{...!props.overrideStyle ? UPCOMING_GAMES_DESKTOP_INNER_STYLE : {}, ...props.style}}>
-             <FilterSet 
-                presets={props.presets}
-                table={_gameProjections}
-                setTable={async (table)=>{
-                    setUpcomingGamesDesktop(table);
-                }}
-                fieldCase={{
-                    "Team Name" : ["TEXT"]
-                }}
-                Title={props.Title}/>
-            <br/>
-            <hr/>
-            <br/>
-            <div className='grid gap-4'>
-                {gameProjections}
-            </div>
+  return (
+    <Wrapper
+      viusage={props.viusage || "wrap"}
+      classNames={[
+        ...(!props.overrideClasses
+          ? UPCOMING_GAMES_DESKTOP_CONTAINER_CLASSNAMES
+          : []),
+        ...(props.classNames || []),
+      ]}
+      style={{
+        ...(!props.overrideStyle ? UPCOMING_GAMES_DESKTOP_CONTAINER_STYLE : {}),
+        ...props.style,
+      }}
+    >
+      <div
+        className={[
+          ...(!props.overrideClasses
+            ? UPCOMING_GAMES_DESKTOP_INNER_CLASSNAMES
+            : []),
+          ...(props.classNames || []),
+        ].join(" ")}
+        style={{
+          ...(!props.overrideStyle ? UPCOMING_GAMES_DESKTOP_INNER_STYLE : {}),
+          ...props.style,
+        }}
+      >
+        <div>
+          <FilterSet
+            presets={props.presets}
+            table={_gameProjections}
+            setTable={async (table) => {
+              setUpcomingGamesDesktop(table);
+            }}
+            fieldCase={{
+              "Team Name": ["TEXT"],
+            }}
+            Title={props.Title}
+          />
+          {/* Use the MatchupCalendar component to allow the user to select a date */}
+          <div className="flex items-center mb-4">
+            <h1 className="text-xl" style={{ marginRight: "20px" }}>
+              {formatDate(selectedDate ? selectedDate : new Date().toString())}
+            </h1>
+            <MatchupCalendar onDateSelect={handleDateSelect} />
+          </div>
         </div>
+        <br />
+        <hr />
+        <br />
+        <div className="grid gap-4">{gameProjections.length > 0 ? gameProjections : "No games available for selected date."}</div>
+      </div>
     </Wrapper>
-    
-    )
+  );
 };

--- a/src/assemblies/data/ncaab/overview/NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames.tsx
+++ b/src/assemblies/data/ncaab/overview/NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames.tsx
@@ -1,52 +1,53 @@
-import React, {FC, ReactElement, useState} from 'react';
-import { ontology, viusage } from '../../../../../util';
-import { UpcomingGames } from '../../matchup';
+import React, { FC, ReactElement, useState } from "react";
+import { ontology, viusage } from "../../../../../util";
+import { UpcomingGames } from "../../matchup";
+import { formatDate } from "../../generic/FormatDate/formatDate";
 
-export const NCAAB_MENS_ALL_UPCOMING_GAMES_CONTAINER_CLASSNAMES : string[] = [ 
-    "p-4"
+export const NCAAB_MENS_ALL_UPCOMING_GAMES_CONTAINER_CLASSNAMES: string[] = [
+  "p-4",
 ];
-export const NCAAB_MENS_ALL_UPCOMING_GAMES_CONTAINER_STYLE : React.CSSProperties = {
-};
+export const NCAAB_MENS_ALL_UPCOMING_GAMES_CONTAINER_STYLE: React.CSSProperties =
+  {};
 
-export const NCAAB_MENS_ALL_UPCOMING_GAMES_INNER_CLASSNAMES : string[] = [ ];
-export const NCAAB_MENS_ALL_UPCOMING_GAMES_INNER_STYLE : React.CSSProperties = {
-    textAlign : "left"
+export const NCAAB_MENS_ALL_UPCOMING_GAMES_INNER_CLASSNAMES: string[] = [];
+export const NCAAB_MENS_ALL_UPCOMING_GAMES_INNER_STYLE: React.CSSProperties = {
+  textAlign: "left",
 };
 
 export type NcaabMensAllUpcomingGamesProps = {
-     children ? : React.ReactNode;
-    style ? : React.CSSProperties;
-    overrideStyle ? : boolean;
-    classNames ? : string[];
-    overrideClasses ? : boolean;
-    responsive ? : boolean;
-    viusage ? : viusage.primary.Viusagelike
-    which ? : string;
-    allUpcomingGames ? : ontology.ProjectedGamelike[];
-    onTeamClick ? : (teamId : string)=>Promise<void>;
-    onMatchupClick ? : (gameId : string)=>Promise<void>;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+  overrideStyle?: boolean;
+  classNames?: string[];
+  overrideClasses?: boolean;
+  responsive?: boolean;
+  viusage?: viusage.primary.Viusagelike;
+  which?: string;
+  allUpcomingGames?: ontology.ProjectedGamelike[];
+  onTeamClick?: (teamId: string) => Promise<void>;
+  onMatchupClick?: (gameId: string) => Promise<void>;
 };
 
-export const isOnTheBubble = (team : ontology.Teamlike)=>{
+export const isOnTheBubble = (team: ontology.Teamlike) => {
+  // ranked teams are not on the bubble
+  if (team.ApRank) return false;
 
-    // ranked teams are not on the bubble
-    if(team.ApRank) return false;
+  const wins = team.Wins || 0;
+  const losses = team.Losses || 0;
+  const total = wins + losses || 1;
+  return wins / total > 0.75;
+};
 
-    const wins = team.Wins||0;
-    const losses = team.Losses||0;
-    const total = (wins + losses)||1;
-    return (wins/total) > .75
-
-}
-
-export const NcaabMensAllUpcomingGames : FC<NcaabMensAllUpcomingGamesProps>  = (props) =>{
-
-    return (
-        <UpcomingGames 
-        stackedGamblers={true}
-        onMatchupClick={props.onMatchupClick}
-        onTeamClick={props.onTeamClick}
-        Title={<h2 className='text-2xl'>Today's Games</h2>}
-        games={props.allUpcomingGames}/>
-    )
+export const NcaabMensAllUpcomingGames: FC<NcaabMensAllUpcomingGamesProps> = (
+  props
+) => {
+  return (
+    <UpcomingGames
+      stackedGamblers={true}
+      onMatchupClick={props.onMatchupClick}
+      onTeamClick={props.onTeamClick}
+      Title={<h2 className="text-2xl">Matchups</h2>}
+      games={props.allUpcomingGames}
+    />
+  );
 };


### PR DESCRIPTION
## About
As a Gameday Guru user, I expect to be able to select a date on the matchup calendar, and see games displayed for the selected date. this should be accomplished in one of two ways:

User can select the “calendar” icon displaying a monthly calendar

## Description of Changes
* Create `MatchupCalendar` component and incorporate into the matchup page
* Remove `MatchupCarousel` at the bottom of the page
* bump component library version for new feature
* add `react-bootstrap-icons` and `react-datepicker` deps

## Trello Ticket
https://trello.com/c/fvuzNGB0/3-matchup-calendar

## Screenshots
![Screenshot 2024-03-06 at 3 32 33 PM](https://github.com/gameday-guru/gdg-component-library/assets/46224768/12bd37f5-4c10-43fb-b219-60dcdd5d78d4)

